### PR TITLE
"ENV key=value" should be used instead of legacy "ENV key value" format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.20.2
 ARG GCLOUD_CLI_VERSION=490.0.0
 ARG INSTALL_COMPONENTS=beta
 
-ENV PATH /google-cloud-sdk/bin:$PATH
-ENV CLOUDSDK_PYTHON /usr/bin/python3
+ENV PATH=/google-cloud-sdk/bin:$PATH
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH="$(cat /tmp/arch)" && apk add --no-cache \


### PR DESCRIPTION
https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/